### PR TITLE
:scroll: Add chat completion request  body example to openapi schema

### DIFF
--- a/config/routes.oas.json
+++ b/config/routes.oas.json
@@ -61,6 +61,15 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChatCompletionRequest"
+              },
+              "example": {
+                "model": "swiss-ai/apertus-8b-instruct",
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "Hello! Can you help me understand open-source AI?"
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
Addressing [#15](https://github.com/forpublicai/platform.publicai.co/issues/15), add a chat completion request body example to the openapi schema in the hope that UI will pick it up and use in the `Test` button flow.

Note: didn't test this since I don't have local development setup.