### PR TITLE
:pencil2: Add shortcut link to API key creation page

### DIFF
--- a/docs/pages/docs.mdx
+++ b/docs/pages/docs.mdx
@@ -15,11 +15,12 @@ To get started, you'll need to create an account and obtain an API key.
 <Stepper>
 1. Click on the _Login_ button on the top right of this portal
 2. Sign up using single sign on 
-3. After sign up, click on your name to reveal the dropdown menu
-4. Click on _API Keys_
-5. Click _Create API Key_
-6. Enter a name for your API Key and select an expiration time
-7. Click _Generate Key_
+3. After sign up, either:
+  - Option A: Go to the [API keys page](/settings/api-keys)
+  - Option B: Click on your name to reveal the dropdown menu and click on _API Keys_
+4. Click _Create API Key_
+5. Enter a name for your API Key and select an expiration time
+6. Click _Generate Key_
 </Stepper>
 
 ### 2. Making Your First Request


### PR DESCRIPTION
Addressing [#15](https://github.com/forpublicai/platform.publicai.co/issues/15), add a shortcut link to the API creation time. This feels (to me) a little bit faster than following the UI instructions with multiple clicks.